### PR TITLE
feat: catch more reachability error variants

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,7 +26,12 @@ SoftwareLog = namedtuple(
     "SoftwareLog", "log_url software entity formatted_error_output datetime"
 )
 
-REACHABILITY_ERRORS = (": forbidden resource", ": i/o timeout")
+REACHABILITY_ERRORS = (
+    ": forbidden resource",
+    ": i/o timeout",
+    "context deadline exceeded",
+    "not reachable",
+)
 
 
 def is_reachability_error(message: str) -> bool:


### PR DESCRIPTION
The crawler emits 'context deadline exceeded' for HTTP client timeouts and a generic 'not reachable' prefix for failed URL checks, neither of which matched the previous patterns.