### PR TITLE
fix: tighten reachability error patterns

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,9 @@ REACHABILITY_ERRORS = (
     ": forbidden resource",
     ": i/o timeout",
     "context deadline exceeded",
-    "not reachable",
+    "no such host",
+    "connection refused",
+    "tls handshake",
 )
 
 


### PR DESCRIPTION
'not reachable' was matching legitimate config errors like 'missing URL scheme'. Match the underlying network errors from httpclient-lib-go and net/http instead.